### PR TITLE
[Fix/modal] 모달 연 상태에서 뒤로가기 시 모든 페이지 스크롤 안되는 문제 해결

### DIFF
--- a/src/Component/SignUp/Terms.tsx
+++ b/src/Component/SignUp/Terms.tsx
@@ -63,7 +63,8 @@ const Terms = ({ isAllAgreed, setIsAllAgreed }: TermsProps): JSX.Element => {
 
   const showModal = () => {
     setIsOpen(true);
-    document.body.style.overflow = 'hidden';
+    // document.body.style.overflow = 'hidden';
+    // window.history.pushState(null, '', window.location.href);
   };
 
   return (

--- a/src/Component/SignUp/TermsModal.tsx
+++ b/src/Component/SignUp/TermsModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import styled from 'styled-components';
 import { ReactComponent as CloseIcon } from '../../image/Icon/close_icon.svg';
 import MarkDown from '../Markdown/Markdown';
@@ -19,9 +20,16 @@ interface TermsModalProps {
 }
 
 const TermsModal = ({ setIsOpen, termsData, setIsAgreed }: TermsModalProps) => {
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, []);
+
   const handleCloseButtonClick = () => {
     setIsOpen(false);
-    document.body.style.overflow = 'unset';
+    // document.body.style.overflow = 'unset';
   };
 
   const handleAgreeButtonClick = () => {
@@ -43,7 +51,7 @@ const TermsModal = ({ setIsOpen, termsData, setIsAgreed }: TermsModalProps) => {
     }
 
     setIsOpen(false);
-    document.body.style.overflow = 'unset';
+    // document.body.style.overflow = 'unset';
   };
 
   return (
@@ -72,6 +80,10 @@ const Container = styled.div`
   bottom: 0;
   z-index: 2;
   background-color: var(--color-white);
+  /* overflow: auto; */
+  /* .scroll::-webkit-scrollbar {
+    display: none;
+  } */
 `;
 
 const ModalHeaderS = styled.div`


### PR DESCRIPTION
## 작업 내용 
useEffect를 사용해 약관동의 모달 연 상태에서 뒤로가기 하면 모든 페이지 스크롤 안되는 문제 해결 

## 코드 
https://github.com/khkh0109/ConnectingChips-Front/blob/3cf116710deb47c7b8e575680426f5f25c2e35d1/src/Component/SignUp/TermsModal.tsx#L22-L28

## 참고사항 
모달이 열렸을때 스크롤을 막는 방법을 시도해봤으나, 스크롤은 잘 되지만 회원가입 스크롤이 여전히 남아있는 문제가 있음 

https://github.com/ConnectingChips/ConnectingChips-Front/assets/77181642/ad4cd38a-8066-4d54-81b3-4bc5fd3c3618

그래서 useEffect 내부에서 모달 스크롤을 제어하는 방식을 시도함 
- 모달 컴포넌트가 마운트됐을때 바디 스크롤 막음 
- 모달 컴포넌트가 언마운트 됐을때 바디 스크롤 해제 

데스크탑 브라우저의 모바일 모드에서 테스트해봤지만, 모바일 브라우저에서는 테스트 못해봄 
만약 모바일 브라우저에서 테스트 했는데 괜찮다면 이 방법으로 하고, 안된다면 이전의 스크롤 방법을 적용하는게 좋을듯 함 

코드 주석은 useEffect 방법이 제대로 안될때 사용하려고 남겨두었는데, 방법이 정해진다면 삭제될 예정 