### PR TITLE
[Fix] 중복된 html meta description 삭제

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,6 @@
     <link rel="icon" href="%PUBLIC_URL%/samchips_favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Web site created using create-react-app" />
     <link rel="preconnect" href="https://fonts.googleapis.com%22%3E/" />
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin />
     <link


### PR DESCRIPTION
## 작업내용 
아래 사진과 같이 CRA 프로젝트 만들때 기본 삽입되어 있는 meta description을 삭제했습니다. 

삭제
<img width="570" alt="스크린샷 2023-09-27 오전 12 17 35" src="https://github.com/ConnectingChips/ConnectingChips-Front/assets/77181642/37486e16-53ca-4fde-9d6d-08e20e0ffacc">

유지
<img width="567" alt="스크린샷 2023-09-27 오전 12 17 47" src="https://github.com/ConnectingChips/ConnectingChips-Front/assets/77181642/ba6c054e-548a-409e-98a8-e9c6ae0635c2">

close #121 
