### PR TITLE
JSSC-89 ✨ Feat : 구글태그매니저를 위한 클래스명 분리

### DIFF
--- a/src/Component/DeleteModal.tsx
+++ b/src/Component/DeleteModal.tsx
@@ -34,7 +34,12 @@ const DeleteModal = ({
           <button className='cancel' onClick={() => setConfirm(false)}>
             취소
           </button>
-          <button className='point' onClick={handleConfirm}>
+          <button
+            className={`point ${
+              confirmText === '이 게시글을 삭제할까요?' ? 'post_point' : 'comment_point'
+            }`}
+            onClick={handleConfirm}
+          >
             {action}
           </button>
         </div>


### PR DESCRIPTION
작심그룹 페이지 게시글 삭제 팝업 / 댓글 삭제 팝업 class명이 둘다 point로 동일합니다만, Google Tag Manager가 두 개의 버튼을 별도 인식할 수 있도록 post_point / comment_point 등 (예시) 으로 수정을 부탁드리고자 합니다.

---

이렇게 요청이 와서 게시글 삭제와 댓글삭제 모달버튼에 따라서 class를 분리하였습니다.