### PR TITLE
[JSSC-138] 이미지 누락 에러 핸들링

### DIFF
--- a/src/API/Boards.ts
+++ b/src/API/Boards.ts
@@ -85,14 +85,16 @@ export const postCreateBoard = async (BoardData: CreateBoard): Promise<PostCreat
   const boardRequestDto = { mindId, userId, content };
   const { tockenHeader } = getToken();
 
+  if (image.file === null) {
+    throw new Error('이미지는 필수입니다.');
+  }
+
   formData.append(
     'boardRequestDto',
     new Blob([JSON.stringify(boardRequestDto)], { type: 'application/json' }),
   );
 
-  if (image.file !== null) {
-    formData.append('file', image.file);
-  }
+  formData.append('file', image.file);
 
   try {
     const response = await postData<PostCreateBoardType>(`/boards`, formData, tockenHeader);

--- a/src/API/Mind.ts
+++ b/src/API/Mind.ts
@@ -13,7 +13,7 @@ export const getMindInfo_Intro = async (mind_id: number): Promise<MindIntroInfo>
     return response.data;
   } catch (error) {
     console.error(error);
-    throw new Error("Failed to get Minds' Info Intro, Upload");
+    return Promise.reject(error);
   }
 };
 

--- a/src/Page/UploadPost/UploadPost.tsx
+++ b/src/Page/UploadPost/UploadPost.tsx
@@ -25,7 +25,7 @@ import { postCreateBoard } from '../../API/Boards';
 import { getMindInfo_Intro } from '../../API/Mind';
 
 import { ReactComponent as LoadingSpinner } from '../../image/loading.svg';
-import { MindIntroInfo, MindsType } from '../../Type/Mind';
+import { MindsType } from '../../Type/Mind';
 import {
   BAD_REQUEST,
   SERVER_ERROR,
@@ -46,7 +46,7 @@ const UploadPost = () => {
   const navigate = useNavigate();
   const { mindId } = useParams();
 
-  const [userId, setUserId] = useState<number>(0);
+  const [userId, setUserId] = useState<number | null>(null); // null로 바꾸기 (혹시 0번 유저가 있을수도 있으니)
   const [imageUrl, setImageUrl] = useState<string>('');
   const [text, setText] = useState<string>(INITIAL_TEXT);
   const [image, setImage] = useState<Image>({ name: '', file: null });
@@ -55,36 +55,47 @@ const UploadPost = () => {
 
   useEffect(() => {
     (async () => {
-      try {
-        const res = await getUser();
-        setUserId(res.userId);
-        getMindInfo_Intro(Number(mindId)).then((data: MindIntroInfo) => setGetMindInfoData(data));
-      } catch (error) {
-        console.error(error);
+      const [getUserData, getMindInfoIntroData] = await Promise.allSettled([
+        getUser(),
+        getMindInfo_Intro(Number(mindId)),
+      ]);
 
-        // TODO: 코드 중복 수정 필요 / 공통으로 처리할 에러 정리 필요
-        if (axios.isAxiosError(error)) {
-          if (error.response?.status === SERVER_ERROR) {
-            return notifyNetErr();
-          }
+      if (getUserData.status === 'fulfilled') {
+        setUserId(getUserData.value.userId);
+      } else {
+        handleAxiosError(getUserData.reason);
+      }
 
-          if (error.response?.data.code === EXPIRED_TOKEN) {
-            localStorage.removeItem('access_token');
-            return navigate('/');
-          }
-
-          if (error.response?.data.code === INVALID_TOKEN) {
-            localStorage.removeItem('access_token');
-            return navigate('/');
-          }
-
-          if (error.code === AXIOS_NETWORK_ERROR) {
-            return notifyNetErr();
-          }
-        }
+      if (getMindInfoIntroData.status === 'fulfilled') {
+        setGetMindInfoData(getMindInfoIntroData.value);
+      } else {
+        handleAxiosError(getMindInfoIntroData.reason);
       }
     })();
   }, []);
+
+  const handleAxiosError = (error: Error) => {
+    // TODO: 코드 중복 수정 필요 / 공통으로 처리할 에러 정리 필요
+    if (axios.isAxiosError(error)) {
+      if (error.response?.status === SERVER_ERROR) {
+        return notifyNetErr();
+      }
+
+      if (error.response?.data.code === EXPIRED_TOKEN) {
+        localStorage.removeItem('access_token');
+        return navigate('/');
+      }
+
+      if (error.response?.data.code === INVALID_TOKEN) {
+        localStorage.removeItem('access_token');
+        return navigate('/');
+      }
+
+      if (error.code === AXIOS_NETWORK_ERROR) {
+        return notifyNetErr();
+      }
+    }
+  };
 
   const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files?.length) return;
@@ -127,6 +138,10 @@ const UploadPost = () => {
       return console.error('이미지는 필수입니다.');
     }
 
+    if (userId === null) {
+      return console.error('userId가 없습니다.');
+    }
+
     try {
       setIsLoading(true);
 
@@ -148,26 +163,9 @@ const UploadPost = () => {
 
       // TODO: 코드 중복 수정 필요 / 공통으로 처리할 에러 정리 필요
       if (axios.isAxiosError(error)) {
-        if (error.response?.status === SERVER_ERROR) {
-          return notifyNetErr();
-        }
-
+        handleAxiosError(error);
         if (error.response?.status === BAD_REQUEST) {
           return console.error('이미지는 필수입니다.');
-        }
-
-        if (error.response?.data.code === EXPIRED_TOKEN) {
-          localStorage.removeItem('access_token');
-          return navigate('/');
-        }
-
-        if (error.response?.data.code === INVALID_TOKEN) {
-          localStorage.removeItem('access_token');
-          return navigate('/');
-        }
-
-        if (error.code === AXIOS_NETWORK_ERROR) {
-          return notifyNetErr();
         }
       }
     }

--- a/src/Page/UploadPost/UploadPost.tsx
+++ b/src/Page/UploadPost/UploadPost.tsx
@@ -27,6 +27,7 @@ import { getMindInfo_Intro } from '../../API/Mind';
 import { ReactComponent as LoadingSpinner } from '../../image/loading.svg';
 import { MindIntroInfo, MindsType } from '../../Type/Mind';
 import {
+  BAD_REQUEST,
   SERVER_ERROR,
   INVALID_TOKEN,
   EXPIRED_TOKEN,
@@ -143,11 +144,16 @@ const UploadPost = () => {
       navigate(`/groupPage/${mindId}`);
     } catch (error) {
       console.error(error);
+      setIsLoading(false);
 
       // TODO: 코드 중복 수정 필요 / 공통으로 처리할 에러 정리 필요
       if (axios.isAxiosError(error)) {
         if (error.response?.status === SERVER_ERROR) {
           return notifyNetErr();
+        }
+
+        if (error.response?.status === BAD_REQUEST) {
+          return console.error('이미지는 필수입니다.');
         }
 
         if (error.response?.data.code === EXPIRED_TOKEN) {

--- a/src/Page/UploadPost/UploadPost.tsx
+++ b/src/Page/UploadPost/UploadPost.tsx
@@ -46,7 +46,7 @@ const UploadPost = () => {
   const navigate = useNavigate();
   const { mindId } = useParams();
 
-  const [userId, setUserId] = useState<number | null>(null); // null로 바꾸기 (혹시 0번 유저가 있을수도 있으니)
+  const [userId, setUserId] = useState<number | null>(null);
   const [imageUrl, setImageUrl] = useState<string>('');
   const [text, setText] = useState<string>(INITIAL_TEXT);
   const [image, setImage] = useState<Image>({ name: '', file: null });

--- a/src/Page/UploadPost/UploadPost.tsx
+++ b/src/Page/UploadPost/UploadPost.tsx
@@ -74,7 +74,7 @@ const UploadPost = () => {
     })();
   }, []);
 
-  const handleAxiosError = (error: Error) => {
+  const handleAxiosError = (error: unknown) => {
     // TODO: 코드 중복 수정 필요 / 공통으로 처리할 에러 정리 필요
     if (axios.isAxiosError(error)) {
       if (error.response?.status === SERVER_ERROR) {
@@ -162,8 +162,8 @@ const UploadPost = () => {
       setIsLoading(false);
 
       // TODO: 코드 중복 수정 필요 / 공통으로 처리할 에러 정리 필요
+      handleAxiosError(error);
       if (axios.isAxiosError(error)) {
-        handleAxiosError(error);
         if (error.response?.status === BAD_REQUEST) {
           return console.error('이미지는 필수입니다.');
         }

--- a/src/constant/error.ts
+++ b/src/constant/error.ts
@@ -1,3 +1,4 @@
+export const BAD_REQUEST = 400;
 export const SERVER_ERROR = 500;
 export const INVALID_TOKEN = 4011;
 export const EXPIRED_TOKEN = 4012;


### PR DESCRIPTION
## 작업내용 
* 이미지 누락 에러 핸들링(status code 400)
* Mind.ts에서 에러 발생 시 Promise.reject(error) 반환되게 변경
* 페이지 진입 시 API 요청 병렬 처리 
  * 인증하기 페이지 진입 시 userId, 페이지를 보여줄때 필요한 데이터를 서버에서 받아옴
  * 기존의 코드는 async/await을 사용해 동기적으로 두 개의 API를 호출했는데, 첫 번째 요청이 실패하면 두 번째 요청이 실행되지 않는다는 문제가 발생함(둘은 독립적인 요청으로 서로 의존성을 가지지 않음)
    ```tsx
    // 기존 코드
    try {
      const res = await getUser();
      setUserId(res.userId);
      
      const getMindInfoIntroData = await getMindInfo_Intro(Number(mindId));
      setGetMindInfoData(getMindInfoIntroData);
    } catch (error) {
      // ...
    }
    ```
  * 실제로 화면을 보여줄때 필요한 데이터(첫 번째 API 요청)를 못 받아 오면 userId(두 번째 API 요청)도 못받아 와서 모든 기능을 사용할 수 없게 되었음
  * 이런 이유 때문에 독립적인 두 개의 API 요청을 Promise.allSettled를 사용해서 병렬적으로 처리하도록 변경함
    ```tsx
    const [getUserData, getMindInfoIntroData] = await Promise.allSettled([
            getUser(), getMindInfo_Intro(Number(mindId))]);
    ```
 

