### PR TITLE
[Jssc 140] ⚠ Fix: 홈 및 마이페이지 레이아웃 수정

### DIFF
--- a/src/Component/Mission/MissionTab.tsx
+++ b/src/Component/Mission/MissionTab.tsx
@@ -60,15 +60,16 @@ const MissionSingle = ({ text, focusBind, index }: MissionSingleProps) => {
 
 export { MissonTab, MissionSingle };
 
-const MissonTabContainerS = styled.div`  
+const MissonTabContainerS = styled.div`
   margin: 0 1rem;
   margin-top: 1rem;
   overflow-x: scroll;
-  
+  padding: 0.5px 0;
+
   &::-webkit-scrollbar {
     display: none;
   }
-`
+`;
 
 /** 2023-08-20 MyMisson.tsx - 작심 중인 리스트 탭 */
 const MissonTabS = styled.ul`

--- a/src/Page/GroupIntro/GroupIntro.tsx
+++ b/src/Page/GroupIntro/GroupIntro.tsx
@@ -53,6 +53,9 @@ const BGDarkS = styled.div`
   width: 100%;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.3);
+
+  display: flex;
+  justify-content: center;
 `;
 
 const GroupContainerS = styled.div`

--- a/src/Page/MyPage/MyPage.tsx
+++ b/src/Page/MyPage/MyPage.tsx
@@ -164,6 +164,7 @@ const ProfileHeaderS = styled.div`
 
 const LimitInfoS = styled.div`
   background: #ffd32c;
+  width: 100%;
   height: 3.25rem;
 
   display: flex;

--- a/src/Page/MyPage/MyPage.tsx
+++ b/src/Page/MyPage/MyPage.tsx
@@ -130,6 +130,8 @@ const GroupBGHeaderS = styled(MyPageHeaderS)`
   background-color: white;
   min-width: var(--width-min);
 
+  padding: 1rem 0;
+
   img {
     position: absolute;
     left: 1.67rem;

--- a/src/Page/MyPage/MyPageMind.tsx
+++ b/src/Page/MyPage/MyPageMind.tsx
@@ -181,6 +181,7 @@ const MindS = styled.li`
     font-weight: 500;
     text-overflow: ellipsis;
     white-space: nowrap;
+    overflow: hidden;
   }
   p.sub {
     color: var(--font-color2);
@@ -202,6 +203,8 @@ const ExitButtonS = styled(myPageButton)`
   border: 1px solid var(--font-color3);
   padding: 0 0.56rem;
   color: #000;
+  min-width: 5.51rem;
+  white-space: nowrap;
 `;
 
 const ReMindButtonS = styled(myPageButton)`

--- a/src/Page/MyPage/MyPageMind.tsx
+++ b/src/Page/MyPage/MyPageMind.tsx
@@ -199,21 +199,31 @@ const myPageButton = styled.button`
 `;
 
 const ExitButtonS = styled(myPageButton)`
+  box-sizing: content-box;
   background-color: #fff;
   border: 1px solid var(--font-color3);
   padding: 0 0.56rem;
   color: #000;
-  min-width: 5.51rem;
+
+  min-width: 4.25rem;
   white-space: nowrap;
 `;
 
 const ReMindButtonS = styled(myPageButton)`
+  box-sizing: content-box;
   background-color: var(--color-main);
   padding: 0 0.94rem;
+
+  min-width: 5.06rem;
+  white-space: nowrap;
 `;
 
 const FullJoinButtonS = styled(myPageButton)`
   background-color: var(--color-disabled2);
   color: var(--color-disabled1);
-  width: 6.9375rem;
+  padding: 0 0.94rem;
+
+  min-width: 5.06rem;
+  white-space: nowrap;
+  box-sizing: content-box;
 `;


### PR DESCRIPTION
[ 홈 ]
작심 그룹 리스트 탭 세로폭 조정 (선 굵기 잘리는 것 방지) - padding 0.5px 0

[ 마이페이지 ]
마이페이지 가로 스크롤 삭제  - padding: 1rem 0;

마이페이지 참여중인 작심 
글자
overflow : hidden

버튼
min-width: 5.51rem;
white-space: nowrap;

다시 참여하기 버튼
FullJoin 상태에서 padding 값 (가입 가능 상태  / 불가능 상태)

참여 불가능 안내창
FullJoin상태시 안내창 width 100%

[ 그룹 인트로 ]
BGDarks flex - center