### PR TITLE
[TEST] 🔨 Refactor: 업로드 페이지 리팩토링

### DIFF
--- a/src/Component/CTA/CTAContainer.tsx
+++ b/src/Component/CTA/CTAContainer.tsx
@@ -69,9 +69,11 @@ const BackButton = (): JSX.Element => {
 /** 2023-08-22 CTAContainer.tsx - 인증하기 버튼 */
 const SubmitButtonCTA = ({ hasImage }: { hasImage: boolean }): JSX.Element => {
   return (
-    <CTAButtonS valid={String(hasImage)} disabled={!hasImage}>
-      인증하기
-    </CTAButtonS>
+    <SubmitButtonWrapperS>
+      <CTAButtonS valid={String(hasImage)} disabled={!hasImage}>
+        인증하기
+      </CTAButtonS>
+    </SubmitButtonWrapperS>
   );
 };
 
@@ -80,11 +82,11 @@ const ErrorCTA = (): JSX.Element => {
   const navigate = useNavigate();
 
   return (
-    <ErrorCTAS>
+    <ErrorButtonWrapperS>
       <CTAButtonS valid={'true'} onClick={() => navigate('/')}>
         메인으로
       </CTAButtonS>
-    </ErrorCTAS>
+    </ErrorButtonWrapperS>
   );
 };
 
@@ -97,7 +99,20 @@ const CTAContainerS = styled.div`
   flex-direction: column-reverse;
 `;
 
-const ErrorCTAS = styled.div`
+const SubmitButtonWrapperS = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: sticky;
+  bottom: 0;
+  background-color: #fff;
+
+  button {
+    width: 100%;
+  }
+`;
+
+const ErrorButtonWrapperS = styled.div`
   position: absolute;
   bottom: 0rem;
   display: flex;

--- a/src/Component/Mission/GroupArticle.tsx
+++ b/src/Component/Mission/GroupArticle.tsx
@@ -20,7 +20,7 @@ export const GroupArticleS = styled.article<{ passsort: PageSort }>`
     props.passsort === 'Intro'
       ? '0 1rem'
       : props.passsort === 'Create'
-      ? '3.75rem 1rem 0.5rem 1rem'
+      ? '0.75rem 1rem 0 1rem'
       : '0.87rem 1rem 1.25rem 1rem'};
 `;
 
@@ -53,6 +53,7 @@ const HeadLineS = styled.div<{ passsort: string }>`
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+  margin-bottom: 0.75rem;
 
   h1 {
     font-size: 1.5rem;
@@ -93,6 +94,7 @@ const MissionRuleS = styled.div<{ passsort: PageSort }>`
   background-color: ${(props) =>
     props.passsort === 'Create' ? 'var(--color-bg)' : 'rgba(255, 255, 255, 0.7)'};
   color: black;
+  margin-bottom: 0.5rem;
   padding: 1rem;
   margin-top: ${(props) => (props.passsort === 'Create' ? '' : '1.25rem')};
   border-radius: 1rem;

--- a/src/Component/UploadPost/CreateExampleImage.tsx
+++ b/src/Component/UploadPost/CreateExampleImage.tsx
@@ -46,7 +46,6 @@ const PostS = styled.article`
   gap: var(--height-gap);
   padding: 1rem;
   border-radius: 1rem;
-  margin: 0 1rem;
   color: var(--font-color1);
   background-color: var(--color-bg);
 `;

--- a/src/Component/UploadPost/UploadImage.tsx
+++ b/src/Component/UploadPost/UploadImage.tsx
@@ -26,9 +26,7 @@ const UploadImage = ({
       <UploadImageTitle />
       {imageUrl ? (
         <AddedImageS>
-          <ImageS>
-            <img src={imageUrl} alt='추가된 이미지' />
-          </ImageS>
+          <img src={imageUrl} alt='추가된 이미지' />
           <DeleteIcon className='delete_icon' onClick={handleDeleteIconClick} />
         </AddedImageS>
       ) : (
@@ -57,10 +55,22 @@ const UploadImageWrapperS = styled(UploadWrapperS)`
   }
 `;
 
-const AddedImageS = styled.div`
+const commonImageS = styled.label`
   width: 5rem;
   height: 5rem;
   position: relative;
+
+  img {
+    width: 5rem;
+    height: 5rem;
+  }
+`;
+
+const AddedImageS = styled(commonImageS)`
+  img {
+    object-fit: cover;
+    border-radius: 0.625rem;
+  }
 
   .delete_icon {
     position: absolute;
@@ -69,29 +79,7 @@ const AddedImageS = styled.div`
   }
 `;
 
-const ImageS = styled.div`
-  width: 5rem;
-  height: 5rem;
-  border-radius: 0.625rem;
-  overflow: hidden;
-
-  img {
-    width: 5rem;
-    height: 5rem;
-    object-fit: cover;
-  }
-`;
-
-const UploadImageS = styled.label`
-  width: 5rem;
-  height: 5rem;
-  position: relative;
-
-  img {
-    width: 5rem;
-    height: 5rem;
-  }
-
+const UploadImageS = styled(commonImageS)`
   .add_icon {
     position: absolute;
     bottom: -11.28px;

--- a/src/Component/UploadPost/UploadPostHeader.tsx
+++ b/src/Component/UploadPost/UploadPostHeader.tsx
@@ -15,6 +15,7 @@ export default UploadPostHeader;
 const UploadPostHeaderS = styled(GroupHeaderContainerS)`
   justify-content: center;
   left: 0;
+  position: sticky;
 
   h1 {
     font-size: var(--header);

--- a/src/Page/UploadPost/UploadPost.tsx
+++ b/src/Page/UploadPost/UploadPost.tsx
@@ -171,35 +171,36 @@ const UploadPost = () => {
     }
   };
 
+  const UploadArea = () => {
+    return isLoading ? (
+      <LoadingSpinnerContainer>
+        <LoadingSpinner />
+      </LoadingSpinnerContainer>
+    ) : (
+      <>
+        <UploadImage
+          imageUrl={imageUrl}
+          handleDeleteIconClick={handleDeleteIconClick}
+          handleFileInputChange={handleFileInputChange}
+          handleFileInputClick={handleFileInputClick}
+        />
+        <UploadText initialText={INITIAL_TEXT} handleTextareaChange={handleTextareaChange} />
+      </>
+    );
+  };
+
   return (
     <CreatePostS>
       <UploadPostHeader />
       <GroupArticleS passsort={'Create'}>
         <HeadLine getMindInfoData={getMindInfoData} passsort={'Create'} />
         <MissionRule getMindInfoData={getMindInfoData} passsort={'Create'} />
+        <CreateExampleImage />
       </GroupArticleS>
-      <CreateExampleImage />
       <DivideBaS />
       <CreateFormS onSubmit={handleFormSubmit}>
-        {isLoading ? (
-          <LoadingSpinnerContainer>
-            <LoadingSpinner />
-          </LoadingSpinnerContainer>
-        ) : (
-          <>
-            <UploadImage
-              imageUrl={imageUrl}
-              handleDeleteIconClick={handleDeleteIconClick}
-              handleFileInputChange={handleFileInputChange}
-              handleFileInputClick={handleFileInputClick}
-            />
-            <UploadText initialText={INITIAL_TEXT} handleTextareaChange={handleTextareaChange} />
-          </>
-        )}
-
-        <SubmitButtonWrapperS>
-          <SubmitButtonCTA hasImage={image.file !== null} />
-        </SubmitButtonWrapperS>
+        <UploadArea />
+        <SubmitButtonCTA hasImage={image.file !== null} />
       </CreateFormS>
     </CreatePostS>
   );
@@ -216,19 +217,6 @@ const CreateFormS = styled.form`
   display: flex;
   flex-direction: column;
   gap: 1rem;
-`;
-
-const SubmitButtonWrapperS = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  position: sticky;
-  bottom: 0;
-  background-color: #fff;
-
-  button {
-    width: 100%;
-  }
 `;
 
 const spin = keyframes`


### PR DESCRIPTION
## UploadPost의 추상화 단계 통일

https://github.com/ConnectingChips/ConnectingChips-Front/blob/fe35b2be7835c0111e9bb4572429a8285a1bd9dd/src/Page/UploadPost/UploadPost.tsx#L192-L206

- <UploadArea /> 컴포넌트 분리하여 Form내에서 CTA와 구분된 부분임을 보다 쉽게 표시
- 다양한 핸들러와의 연결관계를 고려하여 UploadPost 내에서 선언
- 보다 더 추상화의 단계를 비슷하게 맞춤

https://github.com/ConnectingChips/ConnectingChips-Front/blob/fe35b2be7835c0111e9bb4572429a8285a1bd9dd/src/Component/CTA/CTAContainer.tsx#L70-L78

- SubmitButtonCTA 안으로 SubmitButtonWrapperS를 직접 넣어 image의 props단계를 단축
- UploadPost에서 hasImage 를 직접 노출하여 props를 내려주는 의미를 보다 직관적으로 알 수 있음

## UploadPost의 DOM구조 변경 및 스타일 처리
### GroupPost의 상단부 컴포넌트 스타일 구조 수정
https://github.com/ConnectingChips/ConnectingChips-Front/blob/fe35b2be7835c0111e9bb4572429a8285a1bd9dd/src/Page/UploadPost/UploadPost.tsx#L192-L199

### UploadPostHeader : aboslute -> sticky 처리
https://github.com/ConnectingChips/ConnectingChips-Front/blob/fe35b2be7835c0111e9bb4572429a8285a1bd9dd/src/Component/UploadPost/UploadPostHeader.tsx#L15-L18
- 헤더부분을 sticky로 처리

https://github.com/ConnectingChips/ConnectingChips-Front/blob/fe35b2be7835c0111e9bb4572429a8285a1bd9dd/src/Component/Mission/GroupArticle.tsx#L18-L25
- sticky 처리로 인해 발생하는 여백에 맞게 3.75rem -> 0.75rem으로 변경 (Figma와 맞춰보기도 편해짐)

### CreateExampleImage 컴포넌트를 GroupArticleS 컴포넌트에 포함
