### PR TITLE
[JSSC-3] 리프레시 토큰을 사용한 로그인 유지 기능 추가

### DIFF
--- a/src/API/axiosConfig.ts
+++ b/src/API/axiosConfig.ts
@@ -1,14 +1,10 @@
-import axios, { AxiosInstance, AxiosResponse, AxiosRequestConfig } from 'axios';
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 import { EXPIRED_TOKEN } from '../constant/error';
 
 axios.defaults.baseURL = 'https://dev.samchips.com';
-// axios.defaults.baseURL = 'http://ec2-13-209-105-30.ap-northeast-2.compute.amazonaws.com:8080';
 axios.defaults.withCredentials = true;
 
 const client: AxiosInstance = axios.create();
-
-// 인스턴스를 만든 후 기본값 변경하기
-// client.defaults.headers.common['withCredentials'] = true;
 
 client.interceptors.response.use(
   (response) => {


### PR DESCRIPTION
## 작업 내용 
리프레시 토큰을 사용한 로그인 유지 기능 추가
* axios interceptor 기능 사용
  * 응답을 중간에 가로채서 에러 코드가 4012( 액세스 토큰 만료 에러 코드)라면 새 액세스 토큰을 발급 받아서 재요청 보내기
  * 만약 리프레시 토큰이 만료되어서 에러가 발생한다면 catch문에서 (1) 액세스 토큰 삭제 (2) 홈으로 이동시킴

로그인 후 리프레시토큰이 쿠키에 제대로 들어오지 않는 문제 
* `client.defaults.headers.common['withCredentials'] = true;` -> `axios.defaults.withCredentials = true;`로 변경해서 해결
